### PR TITLE
Splash screen fix

### DIFF
--- a/boilerplate.js
+++ b/boilerplate.js
@@ -167,7 +167,7 @@ async function install (context) {
     spinner.stop()
 
     // patch splash screen
-    async function patchSplashScreen() {
+    async function patchSplashScreen () {
       spinner.text = `▸ setting up splash screen`
       spinner.start()
       spinner.text = `▸ setting up splash screen: configuring`
@@ -182,7 +182,7 @@ async function install (context) {
       await system.run(`git apply ${patchPath}`, { stdio: 'ignore' })
       filesystem.remove(`${process.cwd()}/patches/splash-screen`)
     }
-    // await patchSplashScreen()
+    await patchSplashScreen()
     spinner.stop()
   } catch (e) {
     ignite.log(e)

--- a/boilerplate/patches/splash-screen/splash-screen.patch
+++ b/boilerplate/patches/splash-screen/splash-screen.patch
@@ -17208,7 +17208,7 @@ index 36c1405..379305f 100644
   */
  
  #import "AppDelegate.h"
-+#import "SplashScreen.h"
++#import "RNSplashScreen.h"
  
  #import <React/RCTBundleURLProvider.h>
  #import <React/RCTRootView.h>
@@ -17216,7 +17216,7 @@ index 36c1405..379305f 100644
    rootViewController.view = rootView;
    self.window.rootViewController = rootViewController;
    [self.window makeKeyAndVisible];
-+  [SplashScreen show];
++  [RNSplashScreen show];
    return YES;
  }
  


### PR DESCRIPTION
Thanks for your work on updating Ignite! 

It looks like the fix for the splash screen problem was simple: react-native-splash-screen changed the header file and module name (see crazycodeboy/react-native-splash-screen#257).

This PR reenables the splash screen patch, and hand-fixes the include and module name.